### PR TITLE
Initial graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 **/*.rs.bk
 Cargo.lock
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,4 +3,5 @@
 members = [
     "deep",
     "deep-native",
+    "deep-backend-tools",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,5 @@
-[package]
-name = "deep"
-version = "0.1.0"
-authors = ["Geordon Worley <vadixidav@gmail.com>"]
-edition = "2018"
+[workspace]
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
-[dependencies]
+members = [
+    "deep"
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 
 members = [
-    "deep"
+    "deep",
+    "deep-native",
 ]

--- a/deep-backend-tools/Cargo.toml
+++ b/deep-backend-tools/Cargo.toml
@@ -1,10 +1,9 @@
 [package]
-name = "deep-native"
+name = "deep-backend-tools"
 version = "0.1.0"
 authors = ["Geordon Worley <vadixidav@gmail.com>"]
 edition = "2018"
 
 [dependencies]
 deep = { version = "0.1.0", path = "../deep" }
-deep-backend-tools = { version = "0.1.0", path = "../deep-backend-tools" }
-ndarray = "0.13.0"
+failure = "0.1.6"

--- a/deep-backend-tools/Cargo.toml
+++ b/deep-backend-tools/Cargo.toml
@@ -7,3 +7,4 @@ edition = "2018"
 [dependencies]
 deep = { version = "0.1.0", path = "../deep" }
 failure = "0.1.6"
+strum = "0.16.0"

--- a/deep-backend-tools/src/accumulate_tensors.rs
+++ b/deep-backend-tools/src/accumulate_tensors.rs
@@ -6,14 +6,14 @@ pub struct AccumulateTensors<T> {
 }
 
 impl<T> AccumulateTensors<T> {
-    fn new() -> Self {
+    pub fn new() -> Self {
         Self::default()
     }
 }
 
 impl<T> AccumulateTensors<T>
 where
-    T: Default + AddAssign,
+    T: Default + for<'a> AddAssign<&'a T> + 'static,
 {
     fn insert(&mut self, slot: usize, tensors: Vec<T>) {
         use std::collections::hash_map::Entry;
@@ -26,7 +26,7 @@ where
                      than what is being added to it for a given op"
                 );
                 for (at, bt) in o.get_mut().iter_mut().zip(tensors) {
-                    *at += bt;
+                    *at += &bt;
                 }
             }
             Entry::Vacant(v) => {
@@ -38,7 +38,7 @@ where
 
 impl<T> Extend<(usize, Vec<T>)> for AccumulateTensors<T>
 where
-    T: Default + AddAssign,
+    T: Default + for<'a> AddAssign<&'a T> + 'static,
 {
     fn extend<I>(&mut self, iter: I)
     where

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -190,7 +190,7 @@ pub enum ImOp<B: Backend + ?Sized> {
     Add(B::Tensor, B::Tensor),
     Sub(B::Tensor, B::Tensor),
     Square(B::Tensor),
-    Zeros,
+    TrainConst,
 }
 
 impl<B> ImOp<B>
@@ -246,7 +246,7 @@ where
             Op::Add(a, b) => double(a, b, ImOp::Add),
             Op::Sub(a, b) => double(a, b, ImOp::Sub),
             Op::Square(a) => tensor(a).map(ImOp::Square),
-            Op::Zeros(..) => Ok(ImOp::Zeros),
+            Op::TrainConst(..) => Ok(ImOp::TrainConst),
         }
     }
 
@@ -360,7 +360,7 @@ where
             Op::Add(a, b) => binary(a, b, ImOp::Add, ImOp::add, deltas),
             Op::Sub(a, b) => binary(a, b, ImOp::Sub, ImOp::sub, deltas),
             Op::Square(a) => unary(a, ImOp::Square, ImOp::square, deltas),
-            Op::Zeros(..) => nullary(ImOp::Zeros, deltas),
+            Op::TrainConst(..) => nullary(ImOp::TrainConst, deltas),
         }
     }
 }
@@ -374,7 +374,7 @@ where
             ImOp::Add(..) => OpTy::Add,
             ImOp::Sub(..) => OpTy::Sub,
             ImOp::Square(..) => OpTy::Square,
-            ImOp::Zeros => OpTy::Zeros,
+            ImOp::TrainConst => OpTy::TrainConst,
         }
     }
 }

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -57,14 +57,16 @@ where
                     Entry::Occupied(o) => return Ok(o.get()[internal.output].clone()),
                     Entry::Vacant(_) => graph.ops[internal.node].clone(),
                 };
-                let ty = op.into();
-                ImOp::solve(op, self, backend, graph, state, inputs).map(|imop| {
-                    let solutions = backend
+                let ty = (&op).into();
+                ImOp::solve(op, self, backend, graph, state, inputs).and_then(|imop| {
+                    backend
                         .solve(imop, &state[internal.node][..])
-                        .ok_or_else(|| Error::OpHasNoHandler { ty })?;
-                    let output = solutions[internal.output].clone();
-                    self.solved.insert(internal, solutions);
-                    output
+                        .map(|solutions| {
+                            let output = solutions[internal.output].clone();
+                            self.solved.insert(internal, solutions);
+                            output
+                        })
+                        .ok_or_else(|| Error::OpHasNoHandler { ty })
                 })
             }
         }

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -34,11 +34,27 @@ pub struct Tape<B: Backend> {
     solved: HashMap<Internal, Vec<B::Tensor>>,
 }
 
+impl<B, T> Default for Tape<B>
+where
+    B: Feed + Immediate + Backend<Tensor = T>,
+    T: Clone,
+{
+    fn default() -> Self {
+        Self {
+            solved: Default::default(),
+        }
+    }
+}
+
 impl<B, T> Tape<B>
 where
     B: Feed + Immediate + Backend<Tensor = T>,
     T: Clone,
 {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
     pub fn solve(
         &mut self,
         backend: &B,

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -1,6 +1,6 @@
-mod train_table;
+mod accumulate_tensors;
 
-pub use train_table::AccumulateTensors;
+pub use accumulate_tensors::AccumulateTensors;
 
 use deep::*;
 use failure::Fail;

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -30,6 +30,15 @@ pub trait Immediate: Backend {
     fn solve(&self, imop: ImOp<Self>, state: &[Self::Tensor]) -> Option<Vec<Self::Tensor>>;
 }
 
+pub trait Propogate: Backend {
+    fn propogate(
+        &self,
+        imop: ImOp<Self>,
+        state: &[Self::Tensor],
+        output_deltas: &[Self::Tensor],
+    ) -> Option<(ImOp<Self>, Vec<Self::Tensor>)>;
+}
+
 pub struct Tape<B: Backend> {
     solved: HashMap<Internal, Vec<B::Tensor>>,
 }
@@ -86,6 +95,22 @@ where
                 })
             }
         }
+    }
+
+    /// Propogates the output from `output_delta` to all of the pieces that contributed to
+    /// the output specified by `input`.
+    ///
+    /// This process will produce the `Backend::Delta` that can be used to train the state.
+    pub fn backprop(
+        &mut self,
+        backend: &B,
+        graph: &Graph,
+        state: &[Vec<B::Tensor>],
+        inputs: &B::Inputs,
+        input: Input,
+        output_delta: B::Tensor,
+    ) -> Result<B::Delta> {
+        unimplemented!()
     }
 }
 

--- a/deep-backend-tools/src/lib.rs
+++ b/deep-backend-tools/src/lib.rs
@@ -1,0 +1,94 @@
+use deep::*;
+use failure::Fail;
+use std::collections::HashMap;
+use std::rc::Rc;
+
+#[derive(Debug, Fail)]
+pub enum Error {
+    #[fail(display = "input not provided: {}", name)]
+    InputNotProvided { name: String },
+}
+
+type Result<T> = std::result::Result<T, Error>;
+
+pub trait Feed: Backend {
+    fn feed(&self, inputs: &Self::Inputs, name: &str) -> Option<Rc<Self::Tensor>>;
+}
+
+impl<B, T> Feed for B
+where
+    B: Backend<Inputs = HashMap<String, Rc<T>>, Tensor = T>,
+{
+    fn feed(&self, inputs: &HashMap<String, Rc<T>>, name: &str) -> Option<Rc<T>> {
+        inputs.get(name).cloned()
+    }
+}
+
+pub trait Immediate: Backend {
+    fn solve(&self, imop: ImOp<Self>) -> Vec<Rc<Self::Tensor>>;
+}
+
+pub struct Tape<B: Backend> {
+    solved: HashMap<Internal, Vec<Rc<B::Tensor>>>,
+}
+
+impl<B> Tape<B>
+where
+    B: Feed + Immediate,
+{
+    pub fn solve(
+        &mut self,
+        backend: &B,
+        graph: &Graph,
+        inputs: &B::Inputs,
+        input: Input,
+    ) -> Result<Rc<B::Tensor>> {
+        match input {
+            Input::Feed(name) => backend
+                .feed(inputs, &name)
+                .ok_or_else(|| Error::InputNotProvided { name }),
+            Input::Internal(internal) => {
+                use std::collections::hash_map::Entry;
+                let op = match self.solved.entry(internal) {
+                    Entry::Occupied(o) => return Ok(o.get()[internal.output].clone()),
+                    Entry::Vacant(_) => graph.ops[internal.node].clone(),
+                };
+                ImOp::solve(op, self, backend, graph, inputs).map(|imop| {
+                    let solutions = backend.solve(imop);
+                    let output = solutions[internal.output].clone();
+                    self.solved.insert(internal, solutions);
+                    output
+                })
+            }
+        }
+    }
+}
+
+pub enum ImOp<B: Backend + ?Sized> {
+    Add(Rc<B::Tensor>, Rc<B::Tensor>),
+    Sub(Rc<B::Tensor>, Rc<B::Tensor>),
+    Square(Rc<B::Tensor>),
+}
+
+impl<B> ImOp<B>
+where
+    B: Feed + Immediate,
+{
+    fn solve<'a>(
+        op: Op,
+        tape: &'a mut Tape<B>,
+        backend: &B,
+        graph: &Graph,
+        inputs: &B::Inputs,
+    ) -> Result<Self> {
+        let mut tensor = |input| tape.solve(backend, graph, inputs, input);
+        let mut double = |a, b, f: fn(Rc<B::Tensor>, Rc<B::Tensor>) -> Self| {
+            tensor(a).and_then(|a| tensor(b).map(|b| f(a, b)))
+        };
+        match op {
+            Op::Add(a, b) => double(a, b, ImOp::Add),
+            Op::Sub(a, b) => double(a, b, ImOp::Sub),
+            Op::Square(a) => tensor(a).map(ImOp::Square),
+        }
+    }
+}

--- a/deep-backend-tools/src/train_table.rs
+++ b/deep-backend-tools/src/train_table.rs
@@ -1,0 +1,59 @@
+use std::collections::HashMap;
+use std::ops::AddAssign;
+
+pub struct AccumulateTensors<T> {
+    pub table: HashMap<usize, Vec<T>>,
+}
+
+impl<T> AccumulateTensors<T> {
+    fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl<T> AccumulateTensors<T>
+where
+    T: Default + AddAssign,
+{
+    fn insert(&mut self, slot: usize, tensors: Vec<T>) {
+        use std::collections::hash_map::Entry;
+        match self.table.entry(slot) {
+            Entry::Occupied(mut o) => {
+                assert_eq!(
+                    o.get().len(),
+                    tensors.len(),
+                    "AccumulateTensors contains different number of tensors \
+                     than what is being added to it for a given op"
+                );
+                for (at, bt) in o.get_mut().iter_mut().zip(tensors) {
+                    *at += bt;
+                }
+            }
+            Entry::Vacant(v) => {
+                v.insert(tensors);
+            }
+        }
+    }
+}
+
+impl<T> Extend<(usize, Vec<T>)> for AccumulateTensors<T>
+where
+    T: Default + AddAssign,
+{
+    fn extend<I>(&mut self, iter: I)
+    where
+        I: IntoIterator<Item = (usize, Vec<T>)>,
+    {
+        for (slot, tensors) in iter {
+            self.insert(slot, tensors);
+        }
+    }
+}
+
+impl<T> Default for AccumulateTensors<T> {
+    fn default() -> Self {
+        Self {
+            table: HashMap::default(),
+        }
+    }
+}

--- a/deep-native/Cargo.toml
+++ b/deep-native/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2018"
 deep = { version = "0.1.0", path = "../deep" }
 deep-backend-tools = { version = "0.1.0", path = "../deep-backend-tools" }
 ndarray = "0.13.0"
+rand = "0.7.2"

--- a/deep-native/Cargo.toml
+++ b/deep-native/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "deep-native"
+version = "0.1.0"
+authors = ["Geordon Worley <vadixidav@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+deep = { version = "0.1.0", path = "../deep" }
+ndarray = "0.13.0"

--- a/deep-native/Cargo.toml
+++ b/deep-native/Cargo.toml
@@ -8,4 +8,7 @@ edition = "2018"
 deep = { version = "0.1.0", path = "../deep" }
 deep-backend-tools = { version = "0.1.0", path = "../deep-backend-tools" }
 ndarray = "0.13.0"
+rand_core = "0.5.1"
+
+[dev-dependencies]
 rand = "0.7.2"

--- a/deep-native/Cargo.toml
+++ b/deep-native/Cargo.toml
@@ -12,3 +12,4 @@ rand_core = "0.5.1"
 
 [dev-dependencies]
 rand = "0.7.2"
+maplit = "1.0.2"

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -177,3 +177,17 @@ impl Immediate for Native {
             .map(|handler| handler.forward(imop, state))
     }
 }
+
+impl Propogate for Native {
+    fn propogate(
+        &self,
+        imop: ImOp<Self>,
+        state: &[Tsor],
+        output_deltas: &[Tsor],
+    ) -> Option<(ImOp<Self>, Vec<Tsor>)> {
+        let ty = (&imop).into();
+        self.handlers
+            .get(&ty)
+            .map(|handler| handler.backward(imop, state, output_deltas))
+    }
+}

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -116,11 +116,11 @@ impl Backend for Native {
         &self,
         graph: &Graph,
         state: &Self::State,
-        inputs: Self::Inputs,
+        inputs: &Self::Inputs,
         tensor: Input,
     ) -> Result<(Self::Tensor, Self::Internal)> {
         let mut tape = Tape::new();
-        tape.solve(self, graph, &state[..], &inputs, tensor)
+        tape.solve(self, graph, &state[..], inputs, tensor)
             .map(|tensor| (tensor, tape))
     }
 
@@ -133,7 +133,7 @@ impl Backend for Native {
         graph: &Graph,
         state: &Self::State,
         internal: &Self::Internal,
-        inputs: Self::Inputs,
+        inputs: &Self::Inputs,
         tensor: Input,
         output_delta: &Self::Tensor,
     ) -> Result<Self::Delta> {

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -110,7 +110,7 @@ impl Backend for Native {
     /// Tensor type is `ndarray`'s `ArcArray` over dynamic dimension.
     type Tensor = Tsor;
     /// The delta stores a map from nodes in the graph to their recieved gradient.
-    type Delta = HashMap<usize, Vec<Tsor>>;
+    type Delta = AccumulateTensors<Tsor>;
     /// State contains all state data (internal tensors that are being trained or static).
     type State = Vec<Vec<Tsor>>;
     /// Error is the error type for the native backend.
@@ -158,9 +158,17 @@ impl Backend for Native {
         internal: &Self::Internal,
         inputs: &Self::Inputs,
         tensor: Input,
-        output_delta: &Self::Tensor,
+        output_delta: Self::Tensor,
     ) -> Result<Self::Delta> {
-        unimplemented!()
+        internal.backprop(
+            self,
+            graph,
+            &state[..],
+            inputs,
+            tensor,
+            output_delta,
+            AccumulateTensors::new(),
+        )
     }
 
     /// Applies a delta to the graph.

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -7,6 +7,29 @@ use std::iter::{Extend, FromIterator};
 
 pub type Tsor = ArcArray<f32, IxDyn>;
 
+pub fn tsor0(n: f32) -> Tsor {
+    ndarray::arr0(n).into_shared().into_dyn()
+}
+
+pub fn tsor1(n: &[f32]) -> Tsor {
+    ndarray::arr1(n).into_shared().into_dyn()
+}
+
+pub fn tsor2<V>(n: &[V]) -> Tsor
+where
+    V: ndarray::FixedInitializer<Elem = f32> + Clone,
+{
+    ndarray::arr2(n).into_shared().into_dyn()
+}
+
+pub fn tsor3<V, U>(n: &[V]) -> Tsor
+where
+    V: ndarray::FixedInitializer<Elem = U> + Clone,
+    U: ndarray::FixedInitializer<Elem = f32> + Clone,
+{
+    ndarray::arr3(n).into_shared().into_dyn()
+}
+
 pub trait Handler {
     /// This returns the op ty that this handler can execute.
     fn op(&self) -> OpTy;

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -47,7 +47,7 @@ pub trait Handler {
         &self,
         imop: ImOp<Native>,
         state: &[Tsor],
-        output_deltas: &[Tsor],
+        output_delta: (usize, Tsor),
     ) -> (ImOp<Native>, Vec<Tsor>);
 }
 
@@ -183,11 +183,11 @@ impl Propogate for Native {
         &self,
         imop: ImOp<Self>,
         state: &[Tsor],
-        output_deltas: &[Tsor],
+        output_delta: (usize, Tsor),
     ) -> Option<(ImOp<Self>, Vec<Tsor>)> {
         let ty = (&imop).into();
         self.handlers
             .get(&ty)
-            .map(|handler| handler.backward(imop, state, output_deltas))
+            .map(|handler| handler.backward(imop, state, output_delta))
     }
 }

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -173,7 +173,12 @@ impl Backend for Native {
 
     /// Applies a delta to the graph.
     fn train(&self, state: &mut Self::State, delta: &Self::Delta) -> Result<()> {
-        unimplemented!()
+        for (&node, deltas) in &delta.table {
+            for (a, b) in state[node].iter_mut().zip(deltas.iter()) {
+                *a += b;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -1,18 +1,23 @@
 use deep::*;
+use deep_backend_tools::*;
 use ndarray::ArrayD;
 use std::collections::HashMap;
+use std::rc::Rc;
+
+type Tensor = Rc<ArrayD<f32>>;
 
 struct Native;
 
 impl Backend for Native {
     /// The input is a feed dict from strings to tensors.
-    type Inputs = HashMap<String, ArrayD<f32>>;
+    type Inputs = HashMap<String, Tensor>;
     /// The internal type stores all the intermediary computations of the whole graph.
-    type Internal = HashMap<Internal, ArrayD<f32>>;
-    /// The output is a tensor.
-    type Output = ArrayD<f32>;
+    type Internal = HashMap<Internal, Tensor>;
+    /// Tensor type is `ndarray`'s `ArrayD`.
+    type Tensor = Tensor;
     /// The delta stores a map from nodes in the graph to their recieved gradient.
-    type Delta = HashMap<usize, ArrayD<f32>>;
+    type Delta = HashMap<usize, Tensor>;
+    type Error = Error;
 
     /// Gets the output of solving the requested tensor.
     fn forward(
@@ -20,7 +25,7 @@ impl Backend for Native {
         graph: &Graph,
         inputs: Self::Inputs,
         tensor: Input,
-    ) -> (Self::Output, Self::Internal) {
+    ) -> Result<(Self::Tensor, Self::Internal), Error> {
         unimplemented!()
     }
 
@@ -34,13 +39,13 @@ impl Backend for Native {
         internal: &Self::Internal,
         inputs: Self::Inputs,
         tensor: Input,
-        output_delta: &Self::Output,
-    ) -> Self::Delta {
+        output_delta: &Self::Tensor,
+    ) -> Result<Self::Delta, Error> {
         unimplemented!()
     }
 
     /// Applies a delta to the graph.
-    fn train(&self, graph: &mut Graph, delta: &Self::Delta) {
+    fn train(&self, graph: &mut Graph, delta: &Self::Delta) -> Result<(), Error> {
         unimplemented!()
     }
 }

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -1,12 +1,36 @@
 use deep::*;
 use deep_backend_tools::*;
 use ndarray::ArrayD;
+use rand::RngCore;
 use std::collections::HashMap;
 use std::rc::Rc;
 
 type Tensor = Rc<ArrayD<f32>>;
 
-struct Native;
+pub trait Handler {
+    /// This returns the op ty that this handler can execute.
+    fn op(&self) -> OpTy;
+
+    /// This generates the trainable state for this graph node.
+    fn generate_state(&self, op: &Op, rng: &mut dyn RngCore) -> Vec<Tensor>;
+
+    /// This performs forward propogation for the op.
+    fn forward(&self, imop: ImOp<Native>, state: &[Tensor]) -> Vec<Tensor>;
+
+    /// This performs backward propogation for the op.
+    ///
+    /// Returns an `ImOp` of the input gradients along with the trainable state deltas (if any).
+    fn backward(
+        &self,
+        imop: ImOp<Native>,
+        state: &[Tensor],
+        output_deltas: &[Tensor],
+    ) -> (ImOp<Native>, Vec<Tensor>);
+}
+
+pub struct Native {
+    handlers: HashMap<OpTy, Box<dyn Handler>>,
+}
 
 impl Backend for Native {
     /// The input is a feed dict from strings to tensors.
@@ -16,16 +40,38 @@ impl Backend for Native {
     /// Tensor type is `ndarray`'s `ArrayD`.
     type Tensor = Tensor;
     /// The delta stores a map from nodes in the graph to their recieved gradient.
-    type Delta = HashMap<usize, Tensor>;
+    type Delta = HashMap<usize, Vec<Tensor>>;
+    /// State contains all state data (internal tensors that are being trained or static).
+    type State = Vec<Vec<Tensor>>;
+    /// Error is the error type for the native backend.
     type Error = Error;
+
+    /// Generates the initial state for a graph.
+    fn state<R>(&self, graph: &Graph, rng: &mut R) -> Result<Self::State>
+    where
+        R: RngCore,
+    {
+        graph
+            .ops
+            .iter()
+            .map(|op| {
+                let ty = op.into();
+                self.handlers
+                    .get(&ty)
+                    .ok_or_else(|| Error::OpHasNoHandler { ty })
+                    .map(|handler| handler.generate_state(op, rng))
+            })
+            .collect()
+    }
 
     /// Gets the output of solving the requested tensor.
     fn forward(
         &self,
         graph: &Graph,
+        state: &Self::State,
         inputs: Self::Inputs,
         tensor: Input,
-    ) -> Result<(Self::Tensor, Self::Internal), Error> {
+    ) -> Result<(Self::Tensor, Self::Internal)> {
         unimplemented!()
     }
 
@@ -36,16 +82,26 @@ impl Backend for Native {
     fn backward(
         &self,
         graph: &Graph,
+        state: &Self::State,
         internal: &Self::Internal,
         inputs: Self::Inputs,
         tensor: Input,
         output_delta: &Self::Tensor,
-    ) -> Result<Self::Delta, Error> {
+    ) -> Result<Self::Delta> {
         unimplemented!()
     }
 
     /// Applies a delta to the graph.
-    fn train(&self, graph: &mut Graph, delta: &Self::Delta) -> Result<(), Error> {
+    fn train(&self, state: &mut Self::State, delta: &Self::Delta) -> Result<()> {
         unimplemented!()
+    }
+}
+
+impl Immediate for Native {
+    fn solve(&self, imop: ImOp<Self>, state: &[Tensor]) -> Option<Vec<Tensor>> {
+        let ty = (&imop).into();
+        self.handlers
+            .get(&ty)
+            .map(|handler| handler.forward(imop, state))
     }
 }

--- a/deep-native/src/lib.rs
+++ b/deep-native/src/lib.rs
@@ -1,0 +1,46 @@
+use deep::*;
+use ndarray::ArrayD;
+use std::collections::HashMap;
+
+struct Native;
+
+impl Backend for Native {
+    /// The input is a feed dict from strings to tensors.
+    type Inputs = HashMap<String, ArrayD<f32>>;
+    /// The internal type stores all the intermediary computations of the whole graph.
+    type Internal = HashMap<Internal, ArrayD<f32>>;
+    /// The output is a tensor.
+    type Output = ArrayD<f32>;
+    /// The delta stores a map from nodes in the graph to their recieved gradient.
+    type Delta = HashMap<usize, ArrayD<f32>>;
+
+    /// Gets the output of solving the requested tensor.
+    fn forward(
+        &self,
+        graph: &Graph,
+        inputs: Self::Inputs,
+        tensor: Input,
+    ) -> (Self::Output, Self::Internal) {
+        unimplemented!()
+    }
+
+    /// Propogates a delta from the output back to the input via chain rule
+    /// and produces a `Delta` that can be used to update the graph
+    /// with an optimizer. The `Delta` contains all the dE/dx of all internal
+    /// variables.
+    fn backward(
+        &self,
+        graph: &Graph,
+        internal: &Self::Internal,
+        inputs: Self::Inputs,
+        tensor: Input,
+        output_delta: &Self::Output,
+    ) -> Self::Delta {
+        unimplemented!()
+    }
+
+    /// Applies a delta to the graph.
+    fn train(&self, graph: &mut Graph, delta: &Self::Delta) {
+        unimplemented!()
+    }
+}

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -1,0 +1,67 @@
+use deep::*;
+use deep_backend_tools::*;
+use deep_native::*;
+use ndarray::arr1;
+use rand::{thread_rng, RngCore};
+use std::collections::HashMap;
+
+struct Add;
+
+impl Handler for Add {
+    fn op(&self) -> OpTy {
+        OpTy::Add
+    }
+
+    fn generate_state(&self, op: &Op, rng: &mut dyn RngCore) -> Vec<Tsor> {
+        // There are no internal variables to an add operation.
+        vec![]
+    }
+
+    fn forward(&self, imop: ImOp<Native>, state: &[Tsor]) -> Vec<Tsor> {
+        if let ImOp::Add(a, b) = imop {
+            vec![a + b]
+        } else {
+            panic!("got {:?} when OpTy::Add was expected", OpTy::from(&imop));
+        }
+    }
+
+    fn backward(
+        &self,
+        imop: ImOp<Native>,
+        state: &[Tsor],
+        output_deltas: &[Tsor],
+    ) -> (ImOp<Native>, Vec<Tsor>) {
+        (
+            // The gradient goes to both inputs the same.
+            ImOp::Add(output_deltas[0].clone(), output_deltas[0].clone()),
+            // There are no internal variables to provide gradient.
+            vec![],
+        )
+    }
+}
+
+#[test]
+fn forward_add() {
+    let backend = Native::new().handler(Add);
+
+    let mut graph = Graph::new();
+    graph.ops.push(Op::Add(
+        Input::Feed("a".to_owned()),
+        Input::Feed("b".to_owned()),
+    ));
+    let state = backend
+        .state(&graph, &mut thread_rng())
+        .expect("unable to generate state");
+    let feed = vec![
+        ("a".to_owned(), arr1(&[2.0]).into_shared().into_dyn()),
+        ("b".to_owned(), arr1(&[3.0]).into_shared().into_dyn()),
+    ]
+    .into_iter()
+    .collect();
+    let target = Input::Internal(Internal { node: 0, output: 0 });
+    let (output, _) = backend
+        .forward(&graph, &state, feed, target)
+        .expect("unable to do forward prop");
+    let expected = arr1(&[5.0]).into_shared().into_dyn();
+    assert_eq!(output, expected);
+}

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -59,7 +59,7 @@ fn forward_add() {
     .collect();
     let target = Input::Internal(Internal { node: 0, output: 0 });
     let (output, _) = backend
-        .forward(&graph, &state, feed, target)
+        .forward(&graph, &state, &feed, target)
         .expect("unable to do forward prop");
     let expected = arr1(&[5.0]).into_shared().into_dyn();
     assert_eq!(output, expected);

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -3,7 +3,7 @@ use deep_backend_tools::*;
 use deep_native::*;
 use maplit::hashmap;
 use ndarray::arr1;
-use rand::{thread_rng, RngCore};
+use rand::{thread_rng, Rng, RngCore};
 
 struct Add;
 
@@ -40,26 +40,23 @@ impl Handler for Add {
     }
 }
 
-struct Zeros;
+struct Sub;
 
-impl Handler for Zeros {
+impl Handler for Sub {
     fn op(&self) -> OpTy {
-        OpTy::Zeros
+        OpTy::Sub
     }
 
-    fn generate_state(&self, op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
-        if let Op::Zeros(shape) = op {
-            vec![Tsor::zeros(&shape[..])]
-        } else {
-            panic!("got {:?} when Op::Zeros was expected", OpTy::from(op));
-        }
+    fn generate_state(&self, _op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
+        // There are no internal variables to a sub operation.
+        vec![]
     }
 
-    fn forward(&self, imop: ImOp<Native>, state: &[Tsor]) -> Vec<Tsor> {
-        if let ImOp::Zeros = imop {
-            vec![state[0].clone()]
+    fn forward(&self, imop: ImOp<Native>, _state: &[Tsor]) -> Vec<Tsor> {
+        if let ImOp::Sub(a, b) = imop {
+            vec![a - b]
         } else {
-            panic!("got {:?} when OpTy::Zeros was expected", OpTy::from(&imop));
+            panic!("got {:?} when OpTy::Sub was expected", OpTy::from(&imop));
         }
     }
 
@@ -70,8 +67,82 @@ impl Handler for Zeros {
         (_, output_delta): (usize, Tsor),
     ) -> (ImOp<Native>, Vec<Tsor>) {
         let ty: OpTy = (&imop).into();
-        assert_eq!(ty, OpTy::Zeros);
-        (ImOp::Zeros, vec![output_delta])
+        assert_eq!(ty, OpTy::Sub);
+        (ImOp::Sub(output_delta.clone(), -output_delta), vec![])
+    }
+}
+
+struct Square;
+
+impl Handler for Square {
+    fn op(&self) -> OpTy {
+        OpTy::Square
+    }
+
+    fn generate_state(&self, _op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
+        // There are no internal variables to a square operation.
+        vec![]
+    }
+
+    fn forward(&self, imop: ImOp<Native>, _state: &[Tsor]) -> Vec<Tsor> {
+        if let ImOp::Square(a) = imop {
+            vec![a.mapv(|n| n.powi(2)).to_shared()]
+        } else {
+            panic!("got {:?} when OpTy::Square was expected", OpTy::from(&imop));
+        }
+    }
+
+    fn backward(
+        &self,
+        imop: ImOp<Native>,
+        _state: &[Tsor],
+        (_, output_delta): (usize, Tsor),
+    ) -> (ImOp<Native>, Vec<Tsor>) {
+        let ty: OpTy = (&imop).into();
+        assert_eq!(ty, OpTy::Square);
+        if let ImOp::Square(a) = imop {
+            (ImOp::Square(2.0 * a * output_delta), vec![])
+        } else {
+            panic!("got {:?} when OpTy::Square was expected", OpTy::from(&imop));
+        }
+    }
+}
+
+struct TrainConst;
+
+impl Handler for TrainConst {
+    fn op(&self) -> OpTy {
+        OpTy::TrainConst
+    }
+
+    fn generate_state(&self, op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
+        if let Op::TrainConst(shape, value) = op {
+            vec![Tsor::zeros(&shape[..]) + *value as f32]
+        } else {
+            panic!("got {:?} when Op::TrainConst was expected", OpTy::from(op));
+        }
+    }
+
+    fn forward(&self, imop: ImOp<Native>, state: &[Tsor]) -> Vec<Tsor> {
+        if let ImOp::TrainConst = imop {
+            vec![state[0].clone()]
+        } else {
+            panic!(
+                "got {:?} when OpTy::TrainConst was expected",
+                OpTy::from(&imop)
+            );
+        }
+    }
+
+    fn backward(
+        &self,
+        imop: ImOp<Native>,
+        _state: &[Tsor],
+        (_, output_delta): (usize, Tsor),
+    ) -> (ImOp<Native>, Vec<Tsor>) {
+        let ty: OpTy = (&imop).into();
+        assert_eq!(ty, OpTy::TrainConst);
+        (ImOp::TrainConst, vec![output_delta])
     }
 }
 
@@ -98,4 +169,60 @@ fn forward_add() {
     // Validate the output.
     let expected = arr1(&[5.0]).into_shared().into_dyn();
     assert_eq!(output, expected);
+}
+
+#[test]
+fn train_add() {
+    let backend = Native::new()
+        .handler(Add)
+        .handler(Sub)
+        .handler(Square)
+        .handler(TrainConst);
+
+    // Add two input tensors to make an output tensor.
+    let y = Tensor::from("x") + Tensor::train_const(vec![], 0.0);
+
+    // The loss function.
+    let loss = (y - Tensor::from("y")).squared();
+
+    // Generate the state for training the graph for the tensor.
+    let mut state = loss
+        .gen_state(&backend, thread_rng())
+        .expect("unable to generate state");
+
+    // The actual difference.
+    let m = 5.0;
+
+    // The learning rate.
+    let learning_rate = 0.01;
+
+    let mut loss_value = std::f32::NAN;
+
+    for _ in 0..1000 {
+        // Random x value
+        let x = thread_rng().gen();
+        // Compute y
+        let y = x + m;
+        // Inputs
+        let feed = hashmap! {
+            "x".to_owned() => tsor0(x),
+            "y".to_owned() => tsor0(y)
+        };
+
+        // Train the network and get back the loss value.
+        loss_value = loss
+            .gradient_descent(
+                &backend,
+                &mut state,
+                &feed,
+                learning_rate,
+                |t| *t.iter().next().unwrap(),
+                tsor0,
+            )
+            .expect("unable to train");
+        eprintln!("loss at {}", loss_value);
+    }
+
+    // Loss starts around 25.
+    assert!(loss_value < 0.1);
 }

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -27,16 +27,20 @@ impl Handler for Add {
 
     fn backward(
         &self,
-        _imop: ImOp<Native>,
+        imop: ImOp<Native>,
         _state: &[Tsor],
         output_deltas: &[Tsor],
     ) -> (ImOp<Native>, Vec<Tsor>) {
-        (
-            // The gradient goes to both inputs the same.
-            ImOp::Add(output_deltas[0].clone(), output_deltas[0].clone()),
-            // There are no internal variables to provide gradient.
-            vec![],
-        )
+        if let ImOp::Add(..) = imop {
+            (
+                // The gradient goes to both inputs the same.
+                ImOp::Add(output_deltas[0].clone(), output_deltas[0].clone()),
+                // There are no internal variables to provide gradient.
+                vec![],
+            )
+        } else {
+            panic!("got {:?} when OpTy::Add was expected", OpTy::from(&imop));
+        }
     }
 }
 

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -29,18 +29,14 @@ impl Handler for Add {
         &self,
         imop: ImOp<Native>,
         _state: &[Tsor],
-        output_deltas: &[Tsor],
+        (_, output_delta): (usize, Tsor),
     ) -> (ImOp<Native>, Vec<Tsor>) {
-        if let ImOp::Add(..) = imop {
-            (
-                // The gradient goes to both inputs the same.
-                ImOp::Add(output_deltas[0].clone(), output_deltas[0].clone()),
-                // There are no internal variables to provide gradient.
-                vec![],
-            )
-        } else {
-            panic!("got {:?} when OpTy::Add was expected", OpTy::from(&imop));
-        }
+        let ty: OpTy = (&imop).into();
+        assert_eq!(ty, OpTy::Add);
+        (
+            ImOp::Add(output_delta.clone(), output_delta.clone()),
+            vec![],
+        )
     }
 }
 

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -1,6 +1,7 @@
 use deep::*;
 use deep_backend_tools::*;
 use deep_native::*;
+use maplit::hashmap;
 use ndarray::arr1;
 use rand::{thread_rng, RngCore};
 
@@ -43,12 +44,10 @@ impl Handler for Add {
 fn forward_add() {
     let backend = Native::new().handler(Add);
     // Inputs
-    let feed = vec![
-        ("a".to_owned(), arr1(&[2.0]).into_shared().into_dyn()),
-        ("b".to_owned(), arr1(&[3.0]).into_shared().into_dyn()),
-    ]
-    .into_iter()
-    .collect();
+    let feed = hashmap! {
+        "a".to_owned() => tsor1(&[2.0]),
+        "b".to_owned() => tsor1(&[3.0]),
+    };
 
     // Add two input tensors to make an output tensor.
     let c = Tensor::from("a") + Tensor::from("b");

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -40,6 +40,41 @@ impl Handler for Add {
     }
 }
 
+struct Zeros;
+
+impl Handler for Zeros {
+    fn op(&self) -> OpTy {
+        OpTy::Zeros
+    }
+
+    fn generate_state(&self, op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
+        if let Op::Zeros(shape) = op {
+            vec![Tsor::zeros(&shape[..])]
+        } else {
+            panic!("got {:?} when Op::Zeros was expected", OpTy::from(op));
+        }
+    }
+
+    fn forward(&self, imop: ImOp<Native>, state: &[Tsor]) -> Vec<Tsor> {
+        if let ImOp::Zeros = imop {
+            vec![state[0].clone()]
+        } else {
+            panic!("got {:?} when OpTy::Zeros was expected", OpTy::from(&imop));
+        }
+    }
+
+    fn backward(
+        &self,
+        imop: ImOp<Native>,
+        _state: &[Tsor],
+        (_, output_delta): (usize, Tsor),
+    ) -> (ImOp<Native>, Vec<Tsor>) {
+        let ty: OpTy = (&imop).into();
+        assert_eq!(ty, OpTy::Zeros);
+        (ImOp::Zeros, vec![output_delta])
+    }
+}
+
 #[test]
 fn forward_add() {
     let backend = Native::new().handler(Add);

--- a/deep-native/tests/basic.rs
+++ b/deep-native/tests/basic.rs
@@ -3,7 +3,6 @@ use deep_backend_tools::*;
 use deep_native::*;
 use ndarray::arr1;
 use rand::{thread_rng, RngCore};
-use std::collections::HashMap;
 
 struct Add;
 
@@ -12,12 +11,12 @@ impl Handler for Add {
         OpTy::Add
     }
 
-    fn generate_state(&self, op: &Op, rng: &mut dyn RngCore) -> Vec<Tsor> {
+    fn generate_state(&self, _op: &Op, _rng: &mut dyn RngCore) -> Vec<Tsor> {
         // There are no internal variables to an add operation.
         vec![]
     }
 
-    fn forward(&self, imop: ImOp<Native>, state: &[Tsor]) -> Vec<Tsor> {
+    fn forward(&self, imop: ImOp<Native>, _state: &[Tsor]) -> Vec<Tsor> {
         if let ImOp::Add(a, b) = imop {
             vec![a + b]
         } else {
@@ -27,8 +26,8 @@ impl Handler for Add {
 
     fn backward(
         &self,
-        imop: ImOp<Native>,
-        state: &[Tsor],
+        _imop: ImOp<Native>,
+        _state: &[Tsor],
         output_deltas: &[Tsor],
     ) -> (ImOp<Native>, Vec<Tsor>) {
         (

--- a/deep/Cargo.toml
+++ b/deep/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "deep"
+version = "0.1.0"
+authors = ["Geordon Worley <vadixidav@gmail.com>"]
+edition = "2018"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+ndarray = "0.13.0"

--- a/deep/Cargo.toml
+++ b/deep/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2018"
 [dependencies]
 strum = "0.16.0"
 strum_macros = "0.16.0"
-rand = "0.7.2"
+rand_core = "0.5.1"

--- a/deep/Cargo.toml
+++ b/deep/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Geordon Worley <vadixidav@gmail.com>"]
 edition = "2018"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-ndarray = "0.13.0"
+strum = "0.16.0"
+strum_macros = "0.16.0"
+rand = "0.7.2"

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -5,7 +5,7 @@ mod tensor;
 
 pub use tensor::Tensor;
 
-use rand::RngCore;
+use rand_core::RngCore;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Internal {
@@ -76,7 +76,11 @@ pub struct Graph {
 }
 
 impl Graph {
-    fn merge(&mut self, other: Graph) {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn merge(&mut self, other: Graph) {
         let current = self.ops.len();
         self.ops.extend(other.ops);
         for op in &mut self.ops[current..] {
@@ -84,7 +88,7 @@ impl Graph {
         }
     }
 
-    fn merge_input(&mut self, other: Graph, mut input: Input) -> Input {
+    pub fn merge_input(&mut self, other: Graph, mut input: Input) -> Input {
         let current = self.ops.len();
         self.merge(other);
         input.shift_inputs(current);
@@ -101,7 +105,7 @@ pub trait Backend {
     type Error;
 
     /// Generates the initial state for a graph.
-    fn state<R>(&self, graph: &Graph, rng: &mut R) -> Result<Self::State, Self::Error>
+    fn state<R>(&self, graph: &Graph, rng: R) -> Result<Self::State, Self::Error>
     where
         R: RngCore;
 

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -27,6 +27,7 @@ pub enum Op {
     Add(Input, Input),
     Sub(Input, Input),
     Square(Input),
+    Zeros(Vec<usize>),
 }
 
 impl Op {
@@ -43,6 +44,7 @@ impl Op {
             Self::Square(a) => {
                 a.shift_inputs(shift);
             }
+            Self::Zeros(..) => {}
         }
     }
 }

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -4,7 +4,7 @@ pub use tensor::Tensor;
 
 use ndarray::Axis;
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Internal {
     /// The node to pull the input tensor from.
     node: usize,
@@ -22,6 +22,7 @@ impl Internal {
 pub enum Op {
     Add(Input, Input),
     Sub(Input, Input),
+    Square(Input),
     MeanPool(Axis),
 }
 
@@ -35,6 +36,9 @@ impl Op {
             Self::Sub(a, b) => {
                 a.shift_inputs(shift);
                 b.shift_inputs(shift);
+            }
+            Self::Square(a) => {
+                a.shift_inputs(shift);
             }
             _ => {}
         }
@@ -86,7 +90,7 @@ impl Graph {
     }
 }
 
-trait Backend {
+pub trait Backend {
     type Inputs;
     type Internal;
     type Output;

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -129,7 +129,7 @@ pub trait Backend {
         internal: &Self::Internal,
         inputs: &Self::Inputs,
         tensor: Input,
-        output_delta: &Self::Tensor,
+        output_delta: Self::Tensor,
     ) -> Result<Self::Delta, Self::Error>;
 
     /// Applies a delta to the graph's state.

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -1,0 +1,52 @@
+enum Tensor {
+    Input(String),
+    Internal {
+        /// The node to pull the input tensor from.
+        node: usize,
+        /// The specific output to pull from.
+        output: usize,
+    },
+}
+
+struct Node {
+    /// The name of the operation.
+    op: String,
+    /// The inputs to the operation.
+    inputs: Vec<Tensor>,
+}
+
+struct Graph {
+    /// A series of nodes refering to each other's outputs for their input.
+    nodes: Vec<Node>,
+}
+
+trait Backend {
+    type Inputs;
+    type Internal;
+    type Output;
+    type Delta;
+
+    /// Gets all the outputs of solving the requested tensors.
+    fn forward(
+        &self,
+        graph: &Graph,
+        inputs: Self::Inputs,
+        tensor: Tensor,
+    ) -> (Self::Output, Self::Internal);
+
+    /// Propogates a delta from the output back to the input via chain rule
+    /// and produces a `Delta` that can be used to update the graph
+    /// with an optimizer. The `Delta` contains all the dE/dx of all internal
+    /// variables.
+    fn backward(
+        &self,
+        graph: &Graph,
+        internal: &Self::Internal,
+        inputs: Self::Inputs,
+        tensor: Tensor,
+        delta: Self::Output,
+    ) -> (Self::Delta, Self::Output);
+
+    /// Applies a delta to the graph.
+    fn train(&self, graph: &mut Graph, delta: &Self::Delta);
+}

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -44,8 +44,8 @@ trait Backend {
         internal: &Self::Internal,
         inputs: Self::Inputs,
         tensor: Tensor,
-        delta: Self::Output,
-    ) -> (Self::Delta, Self::Output);
+        output_delta: &Self::Output,
+    ) -> Self::Delta;
 
     /// Applies a delta to the graph.
     fn train(&self, graph: &mut Graph, delta: &Self::Delta);

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -114,7 +114,7 @@ pub trait Backend {
         &self,
         graph: &Graph,
         state: &Self::State,
-        inputs: Self::Inputs,
+        inputs: &Self::Inputs,
         tensor: Input,
     ) -> Result<(Self::Tensor, Self::Internal), Self::Error>;
 
@@ -127,7 +127,7 @@ pub trait Backend {
         graph: &Graph,
         state: &Self::State,
         internal: &Self::Internal,
-        inputs: Self::Inputs,
+        inputs: &Self::Inputs,
         tensor: Input,
         output_delta: &Self::Tensor,
     ) -> Result<Self::Delta, Self::Error>;

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -1,23 +1,89 @@
-enum Tensor {
-    Input(String),
-    Internal {
-        /// The node to pull the input tensor from.
-        node: usize,
-        /// The specific output to pull from.
-        output: usize,
-    },
+mod tensor;
+
+pub use tensor::Tensor;
+
+use ndarray::Axis;
+
+#[derive(Clone, Debug)]
+pub struct Internal {
+    /// The node to pull the input tensor from.
+    node: usize,
+    /// The specific output to pull from.
+    output: usize,
 }
 
-struct Node {
-    /// The name of the operation.
-    op: String,
-    /// The inputs to the operation.
-    inputs: Vec<Tensor>,
+impl Internal {
+    fn shift_inputs(&mut self, shift: usize) {
+        self.node += shift;
+    }
 }
 
-struct Graph {
-    /// A series of nodes refering to each other's outputs for their input.
-    nodes: Vec<Node>,
+#[derive(Clone, Debug)]
+pub enum Op {
+    Add(Input, Input),
+    Sub(Input, Input),
+    MeanPool(Axis),
+}
+
+impl Op {
+    fn shift_inputs(&mut self, shift: usize) {
+        match self {
+            Self::Add(a, b) => {
+                a.shift_inputs(shift);
+                b.shift_inputs(shift);
+            }
+            Self::Sub(a, b) => {
+                a.shift_inputs(shift);
+                b.shift_inputs(shift);
+            }
+            _ => {}
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub enum Input {
+    // An input from the feed dict.
+    Feed(String),
+    // An input from another node in the graph.
+    Internal(Internal),
+}
+
+impl Input {
+    fn shift_inputs(&mut self, shift: usize) {
+        if let Self::Internal(n) = self {
+            n.shift_inputs(shift);
+        }
+    }
+}
+
+impl From<&str> for Input {
+    fn from(s: &str) -> Input {
+        Input::Feed(s.to_owned())
+    }
+}
+
+#[derive(Clone, Default, Debug)]
+pub struct Graph {
+    /// A series of ops refering to each other's outputs for their input.
+    ops: Vec<Op>,
+}
+
+impl Graph {
+    fn merge(&mut self, other: Graph) {
+        let current = self.ops.len();
+        self.ops.extend(other.ops);
+        for op in &mut self.ops[current..] {
+            op.shift_inputs(current);
+        }
+    }
+
+    fn merge_input(&mut self, other: Graph, mut input: Input) -> Input {
+        let current = self.ops.len();
+        self.merge(other);
+        input.shift_inputs(current);
+        input
+    }
 }
 
 trait Backend {
@@ -26,12 +92,12 @@ trait Backend {
     type Output;
     type Delta;
 
-    /// Gets all the outputs of solving the requested tensors.
+    /// Gets the output of solving the requested tensor.
     fn forward(
         &self,
         graph: &Graph,
         inputs: Self::Inputs,
-        tensor: Tensor,
+        tensor: Input,
     ) -> (Self::Output, Self::Internal);
 
     /// Propogates a delta from the output back to the input via chain rule
@@ -43,7 +109,7 @@ trait Backend {
         graph: &Graph,
         internal: &Self::Internal,
         inputs: Self::Inputs,
-        tensor: Tensor,
+        tensor: Input,
         output_delta: &Self::Output,
     ) -> Self::Delta;
 

--- a/deep/src/lib.rs
+++ b/deep/src/lib.rs
@@ -27,7 +27,7 @@ pub enum Op {
     Add(Input, Input),
     Sub(Input, Input),
     Square(Input),
-    Zeros(Vec<usize>),
+    TrainConst(Vec<usize>, f64),
 }
 
 impl Op {
@@ -44,7 +44,7 @@ impl Op {
             Self::Square(a) => {
                 a.shift_inputs(shift);
             }
-            Self::Zeros(..) => {}
+            Self::TrainConst(..) => {}
         }
     }
 }
@@ -95,6 +95,12 @@ impl Graph {
         self.merge(other);
         input.shift_inputs(current);
         input
+    }
+
+    /// Returns the node index of the appended op.
+    pub fn append(&mut self, op: Op) -> usize {
+        self.ops.push(op);
+        self.ops.len() - 1
     }
 }
 

--- a/deep/src/tensor.rs
+++ b/deep/src/tensor.rs
@@ -1,0 +1,48 @@
+use crate::{Graph, Input, Internal, Op};
+use std::cell::RefCell;
+use std::ops::{Add, Sub};
+use std::rc::Rc;
+
+pub struct Tensor {
+    graph: Rc<RefCell<Graph>>,
+    input: Input,
+}
+
+impl From<&str> for Tensor {
+    fn from(s: &str) -> Tensor {
+        Tensor {
+            graph: Default::default(),
+            input: s.into(),
+        }
+    }
+}
+
+fn merge2_1(a: Tensor, b: Tensor, make_op: impl Fn(Input, Input) -> Op) -> Tensor {
+    let graph = a.graph;
+    let a = a.input;
+    let b = graph
+        .borrow_mut()
+        .merge_input(b.graph.borrow().clone(), b.input);
+    graph.borrow_mut().ops.push(make_op(a, b));
+    let node = graph.borrow().ops.len() - 1;
+    Tensor {
+        graph,
+        input: Input::Internal(Internal { node, output: 0 }),
+    }
+}
+
+impl Add for Tensor {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self {
+        merge2_1(self, rhs, Op::Add)
+    }
+}
+
+impl Sub for Tensor {
+    type Output = Self;
+
+    fn sub(self, rhs: Self) -> Self {
+        merge2_1(self, rhs, Op::Sub)
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,0 @@
-#[cfg(test)]
-mod tests {
-    #[test]
-    fn it_works() {
-        assert_eq!(2 + 2, 4);
-    }
-}


### PR DESCRIPTION
This creates a graph that is not ideal (see issue #4 for more details), but does work for most machine learning use cases anyways. The approach in the PR initially is to represent all of the available ops that all backends can execute using an enum called `Op`. This approach is likely not what we ultimately intend to use since it doesn't support adding ops downstream, but this PR will be open to discuss this.

The `deep` crate contains the core graph logic and tensor logic. It also contains what defines a backend.

The `deep-native` crate defines the backend for native Rust implemented operations. It specifically chooses to use `ndarray` to represent its tensors. It allows ops to be plugged into it at runtime.

The `deep-backend-tools` crate was created because `deep-native` had several pieces of code that likely apply to all backends. This crate is intended to make the development of future backends easier by allowing the reuse of code. This crate performs the graph forward and backward propogation using a `Tape` struct that remembers previous outputs to avoid re-computation when gradients need to be applied.